### PR TITLE
FISH-899 - Release 3.0.1-b11.payara-p3: Extra logging

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,7 +52,7 @@
     <groupId>javax.el</groupId>
     <artifactId>javax.el-api</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1-b07-SNAPSHOT</version>
+    <version>3.0.1-b11.payara-p3-SNAPSHOT</version>
     <name>Expression Language 3.0 API</name>
 
     <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/api/src/main/java/javax/el/ImportHandler.java
+++ b/api/src/main/java/javax/el/ImportHandler.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright [2021] [Payara Foundation and/or its affiliates]
  */
 
 package javax.el;

--- a/api/src/main/java/javax/el/ImportHandler.java
+++ b/api/src/main/java/javax/el/ImportHandler.java
@@ -46,6 +46,8 @@ import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.lang.reflect.Modifier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Handles imports of class names and package names.  An imported package
@@ -55,6 +57,8 @@ import java.lang.reflect.Modifier;
  * at evaluation time.
  */
 public class ImportHandler {
+
+    private static final Logger logger = Logger.getLogger(ImportHandler.class.getName());
 
     private Map<String, String> classNameMap = new HashMap<String, String>();
     private Map<String, Class<?>> classMap = new HashMap<String, Class<?>>();
@@ -176,6 +180,12 @@ public class ImportHandler {
                 return Class.forName(className, false, Thread.currentThread().getContextClassLoader());
             } catch (ClassNotFoundException ex) {
                 notAClass.add(className);
+                logger.log(Level.FINE, ex.getMessage(), ex);
+            }
+        } else {
+            if (logger.isLoggable(Level.FINER)) {
+                String msg = "Class '" + className + "' not found earlier, skipping loading this class";
+                logger.log(Level.FINER, msg, new ClassNotFoundException(msg));
             }
         }
         return null;

--- a/impl/src/main/java/com/sun/el/ValueExpressionImpl.java
+++ b/impl/src/main/java/com/sun/el/ValueExpressionImpl.java
@@ -222,6 +222,7 @@ public final class ValueExpressionImpl extends ValueExpression implements
             ELException {
         EvaluationContext ctx = new EvaluationContext(context, this.fnMapper,
                 this.varMapper);
+        context.putContext(ValueExpression.class, this.expr);
         ctx.notifyBeforeEvaluation(this.expr);
         Object value = this.getNode().getValue(ctx);
         if (this.expectedType != null) {

--- a/impl/src/main/java/com/sun/el/ValueExpressionImpl.java
+++ b/impl/src/main/java/com/sun/el/ValueExpressionImpl.java
@@ -36,6 +36,8 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ *
+ * Portions Copyright [2021] [Payara Foundation and/or its affiliates]
  */
 
 package com.sun.el;

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,8 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-
+    
+    Portions Copyright [2021] [Payara Foundation and/or its affiliates]
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish</groupId>
     <artifactId>javax.el</artifactId>
-    <version>3.0.1-b11.payara-p2</version>
+    <version>3.0.1-b11.payara-p3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Expression Language 3.0</name>
 


### PR DESCRIPTION
Can be tagged with a release tag for version 3.0.1-b11.payara-p3.

Needs that both the root artifact (impl) and the API artifact in the `api` directory are deployed. The API artifact isn't a submodule of the root module so they need to be deployed separately.

Adds a switch to disable evaluating classes in EL.
Also adds debug logging in case the expression cannot be evaluated.